### PR TITLE
Completely hidden id field if not asked to

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graph-quill",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "GraphQL Schema creation Sugar",
   "main": "lib/index.js",
   "scripts": {

--- a/src/type.js
+++ b/src/type.js
@@ -63,8 +63,8 @@ export function createType<Klass: Object>(
         name,
         description,
         fields: () => Object.assign({},
-          {id: idField && resolveById ?
-            globalIdField(name, obj => obj[idField]) : undefined},
+          idField && resolveById ?
+            {id: globalIdField(name, obj => obj[idField]) } : {},
           fieldMapping(fields, nodeInterface),
           connMapping(connections || {}, nodeInterface)
         ),


### PR DESCRIPTION
Undefined wasn't enough to prevent graphql from skimming through the
field apparently.